### PR TITLE
"Crisis Claw" bug fixes by Yuno1000

### DIFF
--- a/expansions/script/c11111106.lua
+++ b/expansions/script/c11111106.lua
@@ -73,9 +73,9 @@ end
 function cid.thcost(e, tp, eg, ep, ev, re, r, rp, chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(cid.costfilter, tp, LOCATION_HAND, 0, 1, nil, tp) end
 	Duel.Hint(HINT_SELECTMSG, tp, HINTMSG_DISCARD)
-	local tc=Duel.SelectMatchingCard(tp, cid.costfilter, tp, LOCATION_HAND, 0, 1, 1, nil, tp):GetFirst()
-	e:SetLabel(tc:GetType())
-	Duel.DiscardHand(tp, cid.costfilter, 1, 1, REASON_COST+REASON_DISCARD, nil)
+	local tc=Duel.SelectMatchingCard(tp, cid.costfilter, tp, LOCATION_HAND, 0, 1, 1, nil, tp)
+    Duel.SendtoGrave(tc, REASON_COST+REASON_DISCARD)
+    e:SetLabel(tc:GetFirst():GetType())
 end
 function cid.thtg(e, tp, eg, ep, ev, re, r, rp, chk)
 	if chk==0 then return true end

--- a/expansions/script/c11111112.lua
+++ b/expansions/script/c11111112.lua
@@ -51,8 +51,9 @@ function cid.initial_effect(c)
     c:RegisterEffect(e5)
     --Destroy the equipped monster
 	local e6=Effect.CreateEffect(c)
-    e6:SetCategory(CATEGORY_DESTROY)
-    e6:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e6:SetCategory(CATEGORY_DESTROY)
+	e6:SetProperty(EFFECT_FLAG_DELAY)
+    e6:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e6:SetCode(EVENT_DESTROYED)
 	e6:SetCondition(cid.descon)
     e6:SetTarget(cid.destg2)
@@ -110,14 +111,17 @@ function cid.desop1(e, tp, eg, ep, ev, re, r, rp)
 end
 --Destroy the equipped monster
 function cid.descon(e, tp, eg, ep, ev, re, r, rp)
-	return e:GetHandler():IsReason(REASON_EFFECT)
+	local c=e:GetHandler()
+	return c:IsReason(REASON_EFFECT) and c:IsPreviousLocation(LOCATION_ONFIELD)
 end
 function cid.destg2(e, tp, eg, ep, ev, re, r, rp, chk)
 	if chk==0 then return true end
-	Duel.SetOperationInfo(0, CATEGORY_DESTROY, nil, 1, 0, 0)
+    local tc=e:GetHandler():GetPreviousEquipTarget()
+    Duel.SetTargetCard(tc)
+    Duel.SetOperationInfo(0, CATEGORY_DESTROY, tc, 1, 0, 0)
 end
 function cid.desop2(e, tp, eg, ep, ev, re, r, rp)
-	local tc=e:GetHandler():GetFirstCardTarget()
+	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsLocation(LOCATION_MZONE) then
         Duel.Destroy(tc,REASON_EFFECT)
     end

--- a/expansions/script/c11111113.lua
+++ b/expansions/script/c11111113.lua
@@ -66,8 +66,9 @@ function cid.initial_effect(c)
     c:RegisterEffect(e6)
     --Destroy the equipped monster
     local e7=Effect.CreateEffect(c)
-    e7:SetCategory(CATEGORY_DESTROY)
-    e7:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e7:SetCategory(CATEGORY_DESTROY)
+	e7:SetProperty(EFFECT_FLAG_DELAY)
+    e7:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e7:SetCode(EVENT_DESTROYED)
 	e7:SetCondition(cid.descon2)
     e7:SetTarget(cid.destg2)
@@ -109,8 +110,9 @@ function cid.eftg(e, c)
     end
 end
 function cid.negcon(e, tp, eg, ep, ev, re, r, rp)
-	local ex=(Duel.GetOperationInfo(ev,CATEGORY_SEARCH) or re:IsHasCategory(CATEGORY_SEARCH))
-	return rp~=tp and ex and not e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) and Duel.IsChainNegatable(ev)
+	local ex1=(Duel.GetOperationInfo(ev,CATEGORY_SEARCH) or re:IsHasCategory(CATEGORY_SEARCH))
+	local ex2=(Duel.GetOperationInfo(ev,CATEGORY_DRAW) or re:IsHasCategory(CATEGORY_DRAW))
+	return (ex1 or ex2) and rp~=tp and not e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) and Duel.IsChainNegatable(ev)
 end
 function cid.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return not re:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) end
@@ -135,14 +137,17 @@ function cid.desop1(e, tp, eg, ep, ev, re, r, rp)
 end
 --Destroy the equipped monster
 function cid.descon2(e, tp, eg, ep, ev, re, r, rp)
-	return e:GetHandler():IsReason(REASON_EFFECT)
+	local c=e:GetHandler()
+	return c:IsReason(REASON_EFFECT) and c:IsPreviousLocation(LOCATION_ONFIELD)
 end
 function cid.destg2(e, tp, eg, ep, ev, re, r, rp, chk)
 	if chk==0 then return true end
-	Duel.SetOperationInfo(0, CATEGORY_DESTROY, nil, 1, 0, 0)
+    local tc=e:GetHandler():GetPreviousEquipTarget()
+    Duel.SetTargetCard(tc)
+    Duel.SetOperationInfo(0, CATEGORY_DESTROY, tc, 1, 0, 0)
 end
 function cid.desop2(e, tp, eg, ep, ev, re, r, rp)
-	local tc=e:GetHandler():GetFirstCardTarget()
+	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsLocation(LOCATION_MZONE) then
         Duel.Destroy(tc,REASON_EFFECT)
     end

--- a/expansions/script/c11111114.lua
+++ b/expansions/script/c11111114.lua
@@ -50,8 +50,9 @@ function cid.initial_effect(c)
     c:RegisterEffect(e5)
     --Destroy the equipped monster
     local e6=Effect.CreateEffect(c)
-    e6:SetCategory(CATEGORY_DESTROY)
-    e6:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e6:SetCategory(CATEGORY_DESTROY)
+	e6:SetProperty(EFFECT_FLAG_DELAY)
+    e6:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e6:SetCode(EVENT_DESTROYED)
 	e6:SetCondition(cid.descon)
     e6:SetTarget(cid.destg2)
@@ -107,14 +108,17 @@ function cid.desop1(e, tp, eg, ep, ev, re, r, rp)
 end
 --Destroy the equipped monster
 function cid.descon(e, tp, eg, ep, ev, re, r, rp)
-	return e:GetHandler():IsReason(REASON_EFFECT)
+	local c=e:GetHandler()
+	return c:IsReason(REASON_EFFECT) and c:IsPreviousLocation(LOCATION_ONFIELD)
 end
 function cid.destg2(e, tp, eg, ep, ev, re, r, rp, chk)
 	if chk==0 then return true end
-	Duel.SetOperationInfo(0, CATEGORY_DESTROY, nil, 1, 0, 0)
+    local tc=e:GetHandler():GetPreviousEquipTarget()
+    Duel.SetTargetCard(tc)
+    Duel.SetOperationInfo(0, CATEGORY_DESTROY, tc, 1, 0, 0)
 end
 function cid.desop2(e, tp, eg, ep, ev, re, r, rp)
-	local tc=e:GetHandler():GetFirstCardTarget()
+	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsLocation(LOCATION_MZONE) then
         Duel.Destroy(tc,REASON_EFFECT)
     end

--- a/expansions/script/c11111115.lua
+++ b/expansions/script/c11111115.lua
@@ -64,8 +64,9 @@ function cid.initial_effect(c)
     c:RegisterEffect(e6)
     --Destroy the equipped monster
     local e7=Effect.CreateEffect(c)
-    e7:SetCategory(CATEGORY_DESTROY)
-    e7:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e7:SetCategory(CATEGORY_DESTROY)
+	e7:SetProperty(EFFECT_FLAG_DELAY)
+    e7:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e7:SetCode(EVENT_DESTROYED)
 	e7:SetCondition(cid.descon2)
     e7:SetTarget(cid.destg2)
@@ -139,14 +140,17 @@ function cid.desop1(e, tp, eg, ep, ev, re, r, rp)
 end
 --Destroy the equipped monster
 function cid.descon2(e, tp, eg, ep, ev, re, r, rp)
-	return e:GetHandler():IsReason(REASON_EFFECT)
+	local c=e:GetHandler()
+	return c:IsReason(REASON_EFFECT) and c:IsPreviousLocation(LOCATION_ONFIELD)
 end
 function cid.destg2(e, tp, eg, ep, ev, re, r, rp, chk)
 	if chk==0 then return true end
-	Duel.SetOperationInfo(0, CATEGORY_DESTROY, nil, 1, 0, 0)
+    local tc=e:GetHandler():GetPreviousEquipTarget()
+    Duel.SetTargetCard(tc)
+    Duel.SetOperationInfo(0, CATEGORY_DESTROY, tc, 1, 0, 0)
 end
 function cid.desop2(e, tp, eg, ep, ev, re, r, rp)
-	local tc=e:GetHandler():GetFirstCardTarget()
+	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsLocation(LOCATION_MZONE) then
         Duel.Destroy(tc,REASON_EFFECT)
     end

--- a/expansions/script/c11111116.lua
+++ b/expansions/script/c11111116.lua
@@ -52,8 +52,9 @@ function cid.initial_effect(c)
     c:RegisterEffect(e5)
     --Destroy the equipped monster
 	local e6=Effect.CreateEffect(c)
-    e6:SetCategory(CATEGORY_DESTROY)
-    e6:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e6:SetCategory(CATEGORY_DESTROY)
+	e6:SetProperty(EFFECT_FLAG_DELAY)
+    e6:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e6:SetCode(EVENT_DESTROYED)
 	e6:SetCondition(cid.descon)
     e6:SetTarget(cid.destg2)
@@ -111,14 +112,17 @@ function cid.desop1(e, tp, eg, ep, ev, re, r, rp)
 end
 --Destroy the equipped monster
 function cid.descon(e, tp, eg, ep, ev, re, r, rp)
-	return e:GetHandler():IsReason(REASON_EFFECT)
+	local c=e:GetHandler()
+	return c:IsReason(REASON_EFFECT) and c:IsPreviousLocation(LOCATION_ONFIELD)
 end
 function cid.destg2(e, tp, eg, ep, ev, re, r, rp, chk)
 	if chk==0 then return true end
-	Duel.SetOperationInfo(0, CATEGORY_DESTROY, nil, 1, 0, 0)
+    local tc=e:GetHandler():GetPreviousEquipTarget()
+    Duel.SetTargetCard(tc)
+    Duel.SetOperationInfo(0, CATEGORY_DESTROY, tc, 1, 0, 0)
 end
 function cid.desop2(e, tp, eg, ep, ev, re, r, rp)
-	local tc=e:GetHandler():GetFirstCardTarget()
+	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsLocation(LOCATION_MZONE) then
         Duel.Destroy(tc,REASON_EFFECT)
     end

--- a/expansions/script/c11111117.lua
+++ b/expansions/script/c11111117.lua
@@ -69,8 +69,9 @@ function cid.initial_effect(c)
     c:RegisterEffect(e6)
     --Destroy the equipped monster
     local e7=Effect.CreateEffect(c)
-    e7:SetCategory(CATEGORY_DESTROY)
-    e7:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e7:SetCategory(CATEGORY_DESTROY)
+	e7:SetProperty(EFFECT_FLAG_DELAY)
+    e7:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e7:SetCode(EVENT_DESTROYED)
 	e7:SetCondition(cid.descon2)
     e7:SetTarget(cid.destg2)
@@ -171,14 +172,17 @@ function cid.desop1(e, tp, eg, ep, ev, re, r, rp)
 end
 --Destroy the equipped monster
 function cid.descon2(e, tp, eg, ep, ev, re, r, rp)
-	return re and re:GetHandler():GetReason(REASON_EFFECT)
+	local c=e:GetHandler()
+	return c:IsReason(REASON_EFFECT) and c:IsPreviousLocation(LOCATION_ONFIELD)
 end
 function cid.destg2(e, tp, eg, ep, ev, re, r, rp, chk)
 	if chk==0 then return true end
-	Duel.SetOperationInfo(0, CATEGORY_DESTROY, nil, 1, 0, 0)
+    local tc=e:GetHandler():GetPreviousEquipTarget()
+    Duel.SetTargetCard(tc)
+    Duel.SetOperationInfo(0, CATEGORY_DESTROY, tc, 1, 0, 0)
 end
 function cid.desop2(e, tp, eg, ep, ev, re, r, rp)
-	local tc=e:GetHandler():GetFirstCardTarget()
+	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsLocation(LOCATION_MZONE) then
         Duel.Destroy(tc,REASON_EFFECT)
     end

--- a/expansions/script/c11111118.lua
+++ b/expansions/script/c11111118.lua
@@ -67,8 +67,9 @@ function cid.initial_effect(c)
     c:RegisterEffect(e5)
     --Destroy the equipped monster
 	local e6=Effect.CreateEffect(c)
-    e6:SetCategory(CATEGORY_DESTROY)
-    e6:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e6:SetCategory(CATEGORY_DESTROY)
+	e6:SetProperty(EFFECT_FLAG_DELAY)
+    e6:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e6:SetCode(EVENT_DESTROYED)
 	e6:SetCondition(cid.descon)
     e6:SetTarget(cid.destg2)
@@ -149,14 +150,17 @@ function cid.desop1(e, tp, eg, ep, ev, re, r, rp)
 end
 --Destroy the equipped monster and lose LP
 function cid.descon(e, tp, eg, ep, ev, re, r, rp)
-	return e:GetHandler():IsReason(REASON_EFFECT)
+	local c=e:GetHandler()
+	return c:IsReason(REASON_EFFECT) and c:IsPreviousLocation(LOCATION_ONFIELD)
 end
 function cid.destg2(e, tp, eg, ep, ev, re, r, rp, chk)
 	if chk==0 then return true end
-	Duel.SetOperationInfo(0, CATEGORY_DESTROY, nil, 1, 0, 0)
+    local tc=e:GetHandler():GetPreviousEquipTarget()
+    Duel.SetTargetCard(tc)
+    Duel.SetOperationInfo(0, CATEGORY_DESTROY, tc, 1, 0, 0)
 end
 function cid.desop2(e, tp, eg, ep, ev, re, r, rp)
-	local tc=e:GetHandler():GetFirstCardTarget()
+	local tc=Duel.GetFirstTarget()
     if tc:IsLocation(LOCATION_MZONE) and Duel.Destroy(tc,REASON_EFFECT)~=0 then
         Duel.SetLP(tp, Duel.GetLP(tp)-3000)
     end


### PR DESCRIPTION
Apathy was forcing the player to choose the card to discard twice
The equip spells weren't  destroying the equipped monsters